### PR TITLE
Post release tweaks

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,8 @@ include versioneer.py
 include metpy/_version.py
 recursive-include examples *
 recursive-include docs *
+prune docs/build
+prune examples/scripts
+prune docs/source/examples/generated
+prune docs/source/__pycache__
+exclude .ipynb_checkpoints/*

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -112,6 +112,15 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #html_theme = 'default'
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    try:
+        import sphinx_rtd_theme
+        html_theme = 'sphinx_rtd_theme'
+        html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+    except ImportError:
+        pass
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/source/developerguide.rst
+++ b/docs/source/developerguide.rst
@@ -125,3 +125,22 @@ ensure they stay working.
 Test coverage is monitored by `Coveralls.io <https://coveralls.io/r/metpy/MetPy>`_.
 
 `Landscape.io <https://landscape.io/github/metpy/MetPy>`_ is used to track code quality using the ``prospector`` tool.
+
+---------
+Releasing
+---------
+
+To create a new release:
+
+1. Go to the GitHub page and make a new release. The tag should be a sensible version number, like v1.0.0. Add a
+   name (can just be the version) and add some notes on what the big changes are.
+2. Do a pull locally to grab the new tag. This will ensure that ``versioneer`` will give you the proper version.
+3. (optional) Perform a ``git clean -f -x -d`` from the root of the repository. This will **delete** everything not
+   tracked by git, but will also ensure clean source distribution. ``MANIFEST.in`` is set to include/exclude mostly
+   correctly, but could miss some things.
+4. Run ``python setup.py sdist bdist_wheel`` (this requires ``wheel`` is installed).
+5. Upload using ``twine``: ``twine upload dist/*``, assuming the ``dist/`` directory contains only files for this
+   release. This upload process will include any changes to the ``README`` as well as any updated flags from
+   ``setup.py``.
+6. Tagging a new version on GitHub should also update the `stable <http://metpy.readthedocs.org/en/stable>`_  docs on
+   Read the Docs.

--- a/docs/source/developerguide.rst
+++ b/docs/source/developerguide.rst
@@ -9,6 +9,7 @@ Requirements
 - nose
 - flake8
 - sphinx >= 1.3
+- sphinx-rtd-theme >= 0.1.7
 - IPython >= 3.1
 - pandoc (not a python package)
 
@@ -109,7 +110,8 @@ also be converted to standalone scripts using:
 
 The documentation is hosted by `Read the Docs <http://metpy.readthedocs.org>`_. The docs are built automatically
 from ``master`` as well as for the tagged versions on github. ``master`` is used for the ``latest`` documentation,
-and the latest tagged version is used for the ``stable`` documentation.
+and the latest tagged version is used for the ``stable`` documentation. To see what the docs will look like on RTD,
+you also need to install the ``sphinx-rtd-theme`` package.
 
 -----------
 Other Tools

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ Welcome to MetPy's documentation!
 Contents:
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    installguide
    units


### PR DESCRIPTION
A bunch of tweaks that were revealed doing the release. This includes excluding things in the manifest, optionally using the RTD theme when building docs locally, and most importantly, documenting the release steps (since I just did them.)