### PR TITLE
Fix missing units on masked output from heat_index (Fixes #56)

### DIFF
--- a/metpy/calc/basic.py
+++ b/metpy/calc/basic.py
@@ -188,6 +188,6 @@ def heat_index(temperature, rh, mask_undefined=True):
     if mask_undefined:
         mask = np.array((temperature < 80. * units.degF) | (rh < 40))
         if mask.any():
-            hi = masked_array(hi, mask=mask)
+            hi = units.Quantity(masked_array(hi, mask=mask), hi.units)
 
     return hi

--- a/metpy/calc/tests/test_basic.py
+++ b/metpy/calc/tests/test_basic.py
@@ -122,6 +122,13 @@ class TestHeatIndex(object):
         mask = np.array([False] * 6)
         assert_array_equal(hi.mask, mask)
 
+    def test_units(self):
+        'Test units coming out of heat index'
+        temp = units.Quantity([35., 20.], units.degC)
+        rh = 70.
+        hi = heat_index(temp, rh)
+        assert_almost_equal(hi.to('degC'), units.Quantity([50.3405, np.nan], units.degC), 4)
+
 
 # class TestIrrad(object):
 #    def test_basic(self):


### PR DESCRIPTION
`masked_array` was shedding units, so we need to reattach.