### PR TITLE
Nexrad fixes

### DIFF
--- a/metpy/io/nexrad.py
+++ b/metpy/io/nexrad.py
@@ -19,6 +19,7 @@ from .tools import Array, BitField, Bits, DictStruct, Enum, IOBuffer, NamedStruc
 exporter = Exporter(globals())
 
 log = logging.getLogger("metpy.io.nexrad")
+log.addHandler(logging.StreamHandler())  # Python 2.7 needs a handler set
 log.setLevel(logging.WARNING)
 
 
@@ -605,7 +606,7 @@ class Level2File(object):
         # If we're complete, return the full collection of data
         if msg_hdr.num_segments == len(bufs):
             self._msg_buf.pop(msg_hdr.msg_type)
-            return b''.join(item[1] for item in sorted(bufs.items()))
+            return b''.join(bytes(item[1]) for item in sorted(bufs.items()))
 
     def _add_sweep(self, hdr):
         if not self.sweeps and not hdr.rad_status & START_VOLUME:

--- a/metpy/io/tests/test_nexrad.py
+++ b/metpy/io/tests/test_nexrad.py
@@ -1,4 +1,5 @@
 import glob
+import logging
 import os.path
 
 import numpy as np
@@ -8,6 +9,9 @@ from metpy.io.nexrad import Level2File, Level3File, is_precip_mode
 from metpy.cbook import get_test_data
 
 get_test_data = nose.tools.nottest(get_test_data)
+
+# Turn off the warnings for tests
+logging.getLogger("metpy.io.nexrad").setLevel(logging.CRITICAL)
 
 
 def test_level3_generator():
@@ -21,8 +25,9 @@ def read_level3_file(fname):
 
 # 1999 file tests old message 1
 # KFTG tests bzip compression and newer format for a part of message 31
+# KTLX 2015 has missing segments for message 18, which was causing exception
 level2_files = ['KTLX20130520_201643_V06.gz', 'KTLX19990503_235621.gz',
-                'Level2_KFTG_20150430_1419.ar2v']
+                'Level2_KFTG_20150430_1419.ar2v', 'KTLX20150530_000802_V06.bz2']
 
 
 def test_level2_generator():

--- a/metpy/io/tools.py
+++ b/metpy/io/tools.py
@@ -103,7 +103,8 @@ class BitField(object):
             if not val:
                 break
 
-        return l if len(l) > 1 else l[0]
+        # Return whole list if empty or multiple items, otherwise just single item
+        return l[0] if len(l) == 1 else l
 
 
 class Array(object):


### PR DESCRIPTION
Fix a couple of glitches in the NEXRAD code. One was handling a `BitField` that has no values actually set; this came from a malformed file that has unfortunately gone missing. The other is data from KTLX that is missing a couple of message segments. We were getting the last one, which triggered decoding the entire message, which failed. This PR fixes that and warns when we have incomplete multi-segment messages.