### PR TITLE
Replace nosetests with py.test

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,2 @@
 [run]
-omit = metpy/_version.py,metpy/io/nexrad_msgs/parse_spec.py
+omit = metpy/_version.py,metpy/io/nexrad_msgs/parse_spec.py,*/tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.pyc
 
 .coverage
+.cache
 
 .ipynb_checkpoints/
 
@@ -13,6 +14,7 @@ dist/*
 build/*
 *.egg-info
 MANIFEST
+.eggs/
 
 docs/build/
 docs/source/examples/generated

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
     - WHEELDIR="wheelhouse/"
     - EXTRA_INSTALLS="test,cdm"
   matrix:
-    - NOSE_WITH_COVERAGE=y NOSE_COVER_PACKAGE=metpy
+    - TASK="coverage"
     - TASK="examples"
     - TASK="lint"
 
@@ -65,9 +65,8 @@ before_install:
             export EXTRA_INSTALLS="$EXTRA_INSTALLS,examples";
             pip install Cython;
         fi;
-      fi;
-      if [[ $NOSE_WITH_COVERAGE == y ]]; then
-        pip install coverage;
+      elif [[ $TASK == "coverage" ]]; then
+       pip install pytest-cov;
       fi;
       mkdir $WHEELDIR;
       pip install ".[$EXTRA_INSTALLS]" -d $WHEELDIR -f $WHEELHOUSE $PRE $VERSIONS;
@@ -94,12 +93,14 @@ script:
       cd examples;
       echo backend:agg > matplotlibrc;
       MPLBACKEND='agg' TEST_DATA_DIR=${TRAVIS_BUILD_DIR}/testdata python test_examples.py;
+    elif [[ $TASK == "coverage" ]]; then
+      python setup.py test --addopts --cov=metpy;
     else
-      nosetests;
+      python setup.py test;
     fi
 
 after_success:
-  - if [[ $NOSE_WITH_COVERAGE == y ]]; then
+  - if [[ $TASK == "coverage" ]]; then
       pip install codecov codacy-coverage;
       codecov;
       coverage xml;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,14 +13,14 @@ Install metpy:
 
     python setup.py install
 
-Install nose and make sure the tests pass:
+Install py.test and make sure the tests pass:
 
-    pip install nose
-    nosetests
+    pip install pytest
+    py.test
 
 Make your change. Add tests for your change. Make the tests pass:
 
-    nosetests
+    py.test
 
 Push to your fork and [submit a pull request][pr].
 

--- a/docs/source/developerguide.rst
+++ b/docs/source/developerguide.rst
@@ -6,7 +6,7 @@ Developer's Guide
 Requirements
 ------------
 
-- nose
+- pytest
 - flake8
 - sphinx >= 1.3
 - sphinx-rtd-theme >= 0.1.7
@@ -74,7 +74,7 @@ Testing
 -------
 
 Unit tests are the lifeblood of the project, as it ensures that we can continue to add and change the code
-and stay confident that things have not broken. Running the tests requires ``nose``, which is easily available
+and stay confident that things have not broken. Running the tests requires ``pytest``, which is easily available
 through ``conda`` or ``pip``. Running the tests can be done via either:
 
 .. parsed-literal::
@@ -83,14 +83,14 @@ through ``conda`` or ``pip``. Running the tests can be done via either:
 or
 
 .. parsed-literal::
-    nosetests
+    py.test
 
-Using ``nosetests`` also gives you the option of passing a path to the directory with tests to run, which can speed
+Using ``py.test`` also gives you the option of passing a path to the directory with tests to run, which can speed
 running only the tests of interest when doing development. For instance, to only run the tests in the ``metpy/calc``
 directory, use:
 
 .. parsed-literal::
-    nosetests metpy/calc
+    py.test metpy/calc
 
 ----------
 Code Style

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,6 @@ dependencies:
   - netcdf4
   - ipython-notebook
   - sphinx
-  - nose
+  - pytest
   - flake8
   - pep8-naming

--- a/metpy/calc/tests/test_basic.py
+++ b/metpy/calc/tests/test_basic.py
@@ -10,169 +10,161 @@ from metpy.testing import assert_almost_equal, assert_array_almost_equal
 from metpy.calc.basic import *  # noqa
 
 
-class TestWindComps(object):
-    @staticmethod
-    def test_basic():
-        'Test the basic wind component calculation.'
-        speed = np.array([4, 4, 4, 4, 25, 25, 25, 25, 10.]) * units.mph
-        dirs = np.array([0, 45, 90, 135, 180, 225, 270, 315, 360]) * units.deg
-        s2 = np.sqrt(2.)
+def test_wind_comps_basic():
+    'Test the basic wind component calculation.'
+    speed = np.array([4, 4, 4, 4, 25, 25, 25, 25, 10.]) * units.mph
+    dirs = np.array([0, 45, 90, 135, 180, 225, 270, 315, 360]) * units.deg
+    s2 = np.sqrt(2.)
 
-        u, v = get_wind_components(speed, dirs)
+    u, v = get_wind_components(speed, dirs)
 
-        true_u = np.array([0, -4 / s2, -4, -4 / s2, 0, 25 / s2, 25, 25 / s2, 0]) * units.mph
-        true_v = np.array([-4, -4 / s2, 0, 4 / s2, 25, 25 / s2, 0, -25 / s2, -10]) * units.mph
+    true_u = np.array([0, -4 / s2, -4, -4 / s2, 0, 25 / s2, 25, 25 / s2, 0]) * units.mph
+    true_v = np.array([-4, -4 / s2, 0, 4 / s2, 25, 25 / s2, 0, -25 / s2, -10]) * units.mph
 
-        assert_array_almost_equal(true_u, u, 4)
-        assert_array_almost_equal(true_v, v, 4)
-
-    @staticmethod
-    def test_scalar():
-        'Test scalar wind components'
-        u, v = get_wind_components(8 * units('m/s'), 150 * units.deg)
-        assert_almost_equal(u, -4 * units('m/s'), 3)
-        assert_almost_equal(v, 6.9282 * units('m/s'), 3)
+    assert_array_almost_equal(true_u, u, 4)
+    assert_array_almost_equal(true_v, v, 4)
 
 
-class TestSpeedDir(object):
-    @staticmethod
-    def test_speed():
-        'Basic test of wind speed calculation'
-        u = np.array([4., 2., 0., 0.]) * units('m/s')
-        v = np.array([0., 2., 4., 0.]) * units('m/s')
-
-        speed = get_wind_speed(u, v)
-
-        s2 = np.sqrt(2.)
-        true_speed = np.array([4., 2 * s2, 4., 0.]) * units('m/s')
-
-        assert_array_almost_equal(true_speed, speed, 4)
-
-    @staticmethod
-    def test_dir():
-        'Basic test of wind direction calculation'
-        u = np.array([4., 2., 0., 0.]) * units('m/s')
-        v = np.array([0., 2., 4., 0.]) * units('m/s')
-
-        direc = get_wind_dir(u, v)
-
-        true_dir = np.array([90., 45., 0., 90.]) * units.deg
-
-        assert_array_almost_equal(true_dir, direc, 4)
-
-    @staticmethod
-    def test_scalar_speed():
-        'Test wind speed with scalars'
-        s = get_wind_speed(-3. * units('m/s'), -4. * units('m/s'))
-        assert_almost_equal(s, 5. * units('m/s'), 3)
-
-    @staticmethod
-    def test_scalar_dir():
-        'Test wind direction with scalars'
-        d = get_wind_dir(-3. * units('m/s'), -4. * units('m/s'))
-        assert_almost_equal(d, 216.870 * units.deg, 3)
+def test_wind_comps_scalar():
+    'Test scalar wind components'
+    u, v = get_wind_components(8 * units('m/s'), 150 * units.deg)
+    assert_almost_equal(u, -4 * units('m/s'), 3)
+    assert_almost_equal(v, 6.9282 * units('m/s'), 3)
 
 
-class TestWindChill(object):
-    @staticmethod
-    def test_scalar():
-        'Test wind chill with scalars'
-        wc = windchill(-5 * units.degC, 35 * units('m/s'))
-        assert_almost_equal(wc, -18.9357 * units.degC, 0)
+def test_speed():
+    'Basic test of wind speed calculation'
+    u = np.array([4., 2., 0., 0.]) * units('m/s')
+    v = np.array([0., 2., 4., 0.]) * units('m/s')
 
-    @staticmethod
-    def test_basic():
-        'Test the basic wind chill calculation.'
-        temp = np.array([40, -10, -45, 20]) * units.degF
-        speed = np.array([5, 55, 25, 15]) * units.mph
+    speed = get_wind_speed(u, v)
 
-        wc = windchill(temp, speed)
-        values = np.array([36, -46, -84, 6]) * units.degF
-        assert_array_almost_equal(wc, values, 0)
+    s2 = np.sqrt(2.)
+    true_speed = np.array([4., 2 * s2, 4., 0.]) * units('m/s')
 
-    @staticmethod
-    def test_invalid():
-        'Test for values that should be masked.'
-        temp = np.array([10, 51, 49, 60, 80, 81]) * units.degF
-        speed = np.array([4, 4, 3, 1, 10, 39]) * units.mph
-
-        wc = windchill(temp, speed)
-        mask = np.array([False, True, True, True, True, True])
-        assert_array_equal(wc.mask, mask)
-
-    @staticmethod
-    def test_undefined_flag():
-        'Tests whether masking values can be disabled.'
-        temp = units.Quantity(np.ma.array([49, 50, 49, 60, 80, 81]), units.degF)
-        speed = units.Quantity(([4, 4, 3, 1, 10, 39]), units.mph)
-
-        wc = windchill(temp, speed, mask_undefined=False)
-        mask = np.array([False] * 6)
-        assert_array_equal(wc.mask, mask)
-
-    @staticmethod
-    def test_face_level():
-        'Tests using the face_level flag'
-        temp = np.array([20, 0, -20, -40]) * units.degF
-        speed = np.array([15, 30, 45, 60]) * units.mph
-
-        wc = windchill(temp, speed, face_level_winds=True)
-        values = np.array([3, -30, -64, -98]) * units.degF
-        assert_array_almost_equal(wc, values, 0)
+    assert_array_almost_equal(true_speed, speed, 4)
 
 
-class TestHeatIndex(object):
-    @staticmethod
-    def test_basic():
-        'Test the basic heat index calculation.'
-        temp = np.array([80, 88, 92, 110]) * units.degF
-        rh = np.array([40, 100, 70, 40]) * units.percent
+def test_dir():
+    'Basic test of wind direction calculation'
+    u = np.array([4., 2., 0., 0.]) * units('m/s')
+    v = np.array([0., 2., 4., 0.]) * units('m/s')
 
-        hi = heat_index(temp, rh)
-        values = np.array([80, 121, 112, 136]) * units.degF
-        assert_array_almost_equal(hi, values, 0)
+    direc = get_wind_dir(u, v)
 
-    @staticmethod
-    def test_scalar():
-        'Test heat index using scalars'
-        hi = heat_index(96 * units.degF, 65 * units.percent)
-        assert_almost_equal(hi, 121 * units.degF, 0)
+    true_dir = np.array([90., 45., 0., 90.]) * units.deg
 
-    @staticmethod
-    def test_invalid():
-        'Test for values that should be masked.'
-        temp = np.array([80, 88, 92, 79, 30, 81]) * units.degF
-        rh = np.array([40, 39, 2, 70, 50, 39]) * units.percent
+    assert_array_almost_equal(true_dir, direc, 4)
 
-        hi = heat_index(temp, rh)
-        mask = np.array([False, True, True, True, True, True])
-        assert_array_equal(hi.mask, mask)
 
-    @staticmethod
-    def test_undefined_flag():
-        'Tests whether masking values can be disabled.'
-        temp = units.Quantity(np.ma.array([80, 88, 92, 79, 30, 81]), units.degF)
-        rh = np.ma.array([40, 39, 2, 70, 50, 39]) * units.percent
+def test_scalar_speed():
+    'Test wind speed with scalars'
+    s = get_wind_speed(-3. * units('m/s'), -4. * units('m/s'))
+    assert_almost_equal(s, 5. * units('m/s'), 3)
 
-        hi = heat_index(temp, rh, mask_undefined=False)
-        mask = np.array([False] * 6)
-        assert_array_equal(hi.mask, mask)
 
-    @staticmethod
-    def test_units():
-        'Test units coming out of heat index'
-        temp = units.Quantity([35., 20.], units.degC)
-        rh = 70 * units.percent
-        hi = heat_index(temp, rh)
-        assert_almost_equal(hi.to('degC'), units.Quantity([50.3405, np.nan], units.degC), 4)
+def test_scalar_dir():
+    'Test wind direction with scalars'
+    d = get_wind_dir(-3. * units('m/s'), -4. * units('m/s'))
+    assert_almost_equal(d, 216.870 * units.deg, 3)
 
-    @staticmethod
-    def test_ratio():
-        'Test giving humidity as number [0, 1]'
-        temp = units.Quantity([35., 20.], units.degC)
-        rh = 0.7
-        hi = heat_index(temp, rh)
-        assert_almost_equal(hi.to('degC'), units.Quantity([50.3405, np.nan], units.degC), 4)
+
+def test_windchill_scalar():
+    'Test wind chill with scalars'
+    wc = windchill(-5 * units.degC, 35 * units('m/s'))
+    assert_almost_equal(wc, -18.9357 * units.degC, 0)
+
+
+def test_windchill_basic():
+    'Test the basic wind chill calculation.'
+    temp = np.array([40, -10, -45, 20]) * units.degF
+    speed = np.array([5, 55, 25, 15]) * units.mph
+
+    wc = windchill(temp, speed)
+    values = np.array([36, -46, -84, 6]) * units.degF
+    assert_array_almost_equal(wc, values, 0)
+
+
+def test_windchill_invalid():
+    'Test for values that should be masked.'
+    temp = np.array([10, 51, 49, 60, 80, 81]) * units.degF
+    speed = np.array([4, 4, 3, 1, 10, 39]) * units.mph
+
+    wc = windchill(temp, speed)
+    mask = np.array([False, True, True, True, True, True])
+    assert_array_equal(wc.mask, mask)
+
+
+def test_windchill_undefined_flag():
+    'Tests whether masking values can be disabled.'
+    temp = units.Quantity(np.ma.array([49, 50, 49, 60, 80, 81]), units.degF)
+    speed = units.Quantity(([4, 4, 3, 1, 10, 39]), units.mph)
+
+    wc = windchill(temp, speed, mask_undefined=False)
+    mask = np.array([False] * 6)
+    assert_array_equal(wc.mask, mask)
+
+
+def test_windchill_face_level():
+    'Tests using the face_level flag'
+    temp = np.array([20, 0, -20, -40]) * units.degF
+    speed = np.array([15, 30, 45, 60]) * units.mph
+
+    wc = windchill(temp, speed, face_level_winds=True)
+    values = np.array([3, -30, -64, -98]) * units.degF
+    assert_array_almost_equal(wc, values, 0)
+
+
+def test_heat_index_basic():
+    'Test the basic heat index calculation.'
+    temp = np.array([80, 88, 92, 110]) * units.degF
+    rh = np.array([40, 100, 70, 40]) * units.percent
+
+    hi = heat_index(temp, rh)
+    values = np.array([80, 121, 112, 136]) * units.degF
+    assert_array_almost_equal(hi, values, 0)
+
+
+def test_heat_index_scalar():
+    'Test heat index using scalars'
+    hi = heat_index(96 * units.degF, 65 * units.percent)
+    assert_almost_equal(hi, 121 * units.degF, 0)
+
+
+def test_heat_index_invalid():
+    'Test for values that should be masked.'
+    temp = np.array([80, 88, 92, 79, 30, 81]) * units.degF
+    rh = np.array([40, 39, 2, 70, 50, 39]) * units.percent
+
+    hi = heat_index(temp, rh)
+    mask = np.array([False, True, True, True, True, True])
+    assert_array_equal(hi.mask, mask)
+
+
+def test_heat_index_undefined_flag():
+    'Tests whether masking values can be disabled.'
+    temp = units.Quantity(np.ma.array([80, 88, 92, 79, 30, 81]), units.degF)
+    rh = np.ma.array([40, 39, 2, 70, 50, 39]) * units.percent
+
+    hi = heat_index(temp, rh, mask_undefined=False)
+    mask = np.array([False] * 6)
+    assert_array_equal(hi.mask, mask)
+
+
+def test_heat_index_units():
+    'Test units coming out of heat index'
+    temp = units.Quantity([35., 20.], units.degC)
+    rh = 70 * units.percent
+    hi = heat_index(temp, rh)
+    assert_almost_equal(hi.to('degC'), units.Quantity([50.3405, np.nan], units.degC), 4)
+
+
+def test_heat_index_ratio():
+    'Test giving humidity as number [0, 1]'
+    temp = units.Quantity([35., 20.], units.degC)
+    rh = 0.7
+    hi = heat_index(temp, rh)
+    assert_almost_equal(hi.to('degC'), units.Quantity([50.3405, np.nan], units.degC), 4)
 
 # class TestIrrad(object):
 #    def test_basic(self):

--- a/metpy/io/tests/test_cdm.py
+++ b/metpy/io/tests/test_cdm.py
@@ -3,110 +3,106 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np
-from nose.tools import raises
+import pytest
 
 from metpy.io.cdm import Dataset
 
 
-class TestCDM(object):
-    r'Tests for the CDM interface'
+def test_group():
+    r'Test Group/Dataset behavior'
+    ds = Dataset()
+    ds.createDimension('x', 5)
+    ds.createVariable('data', 'f4', ('x',), 5)
+    ds.conventions = 'CF-1.5'
 
-    @staticmethod
-    def test_group():
-        r'Test Group/Dataset behavior'
-        ds = Dataset()
-        ds.createDimension('x', 5)
-        ds.createVariable('data', 'f4', ('x',), 5)
-        ds.conventions = 'CF-1.5'
+    assert 'x' in ds.dimensions
+    assert 'data' in ds.variables
+    assert 'conventions' in ds.ncattrs()
 
-        assert 'x' in ds.dimensions
-        assert 'data' in ds.variables
-        assert 'conventions' in ds.ncattrs()
+    assert str(ds) == ("root\n\nDimensions:\n"
+                       "<class 'metpy.io.cdm.Dimension'>: name = x, size = 5\n\n"
+                       "Variables:\n<class 'metpy.io.cdm.Variable'>: float32 data(x)\n\t"
+                       "shape = 5\n\nAttributes:\n\tconventions: CF-1.5")
 
-        assert str(ds) == ("root\n\nDimensions:\n"
-                           "<class 'metpy.io.cdm.Dimension'>: name = x, size = 5\n\n"
-                           "Variables:\n<class 'metpy.io.cdm.Variable'>: float32 data(x)\n\t"
-                           "shape = 5\n\nAttributes:\n\tconventions: CF-1.5")
 
-    @staticmethod
-    def test_dim():
-        r'Test Dimension behavior'
-        ds = Dataset()
-        dim = ds.createDimension('x', 5)
-        assert dim.size == 5
-        assert dim.group() is ds
-        assert str(dim) == "<class 'metpy.io.cdm.Dimension'>: name = x, size = 5"
+def test_dim():
+    r'Test Dimension behavior'
+    ds = Dataset()
+    dim = ds.createDimension('x', 5)
+    assert dim.size == 5
+    assert dim.group() is ds
+    assert str(dim) == "<class 'metpy.io.cdm.Dimension'>: name = x, size = 5"
 
-    @staticmethod
-    def test_var():
-        r'Test Variable behavior'
-        ds = Dataset()
-        ds.createDimension('x', 2)
-        var = ds.createVariable('data', 'f4', ('x',), 5)
 
-        assert 'data' in ds.variables
-        assert var.shape == (2,)
-        assert var.size == 2
-        assert var.ndim == 1
-        assert var.dtype == np.float32
-        assert var[0] == 5
+def test_var():
+    r'Test Variable behavior'
+    ds = Dataset()
+    ds.createDimension('x', 2)
+    var = ds.createVariable('data', 'f4', ('x',), 5)
 
-        var.units = 'meters'
+    assert 'data' in ds.variables
+    assert var.shape == (2,)
+    assert var.size == 2
+    assert var.ndim == 1
+    assert var.dtype == np.float32
+    assert var[0] == 5
 
-        assert 'units' in var.ncattrs()
-        assert var.units == 'meters'
+    var.units = 'meters'
 
-        assert var.group() is ds
+    assert 'units' in var.ncattrs()
+    assert var.units == 'meters'
 
-        assert str(var) == ("<class 'metpy.io.cdm.Variable'>: float32 data(x)"
-                            "\n\tunits: meters\n\tshape = 2")
+    assert var.group() is ds
 
-    @staticmethod
-    def test_multidim_var():
-        r'Test multi-dim Variable'
-        ds = Dataset()
-        ds.createDimension('x', 2)
-        ds.createDimension('y', 3)
-        var = ds.createVariable('data', 'i8', ('x', 'y'))
+    assert str(var) == ("<class 'metpy.io.cdm.Variable'>: float32 data(x)"
+                        "\n\tunits: meters\n\tshape = 2")
 
-        assert var.shape == (2, 3)
-        assert var.size == 6
-        assert var.ndim == 2
-        assert var.dtype == np.int64
 
-        assert str(var) == ("<class 'metpy.io.cdm.Variable'>: int64 data(x, y)"
-                            "\n\tshape = (2, 3)")
+def test_multidim_var():
+    r'Test multi-dim Variable'
+    ds = Dataset()
+    ds.createDimension('x', 2)
+    ds.createDimension('y', 3)
+    var = ds.createVariable('data', 'i8', ('x', 'y'))
 
-    @staticmethod
-    def test_remove_attr():
-        r'Test removing an attribute'
-        ds = Dataset()
-        ds.maker = 'me'
-        assert 'maker' in ds.ncattrs()
+    assert var.shape == (2, 3)
+    assert var.size == 6
+    assert var.ndim == 2
+    assert var.dtype == np.int64
 
-        del ds.maker
-        assert not hasattr(ds, 'maker')
-        assert 'maker' not in ds.ncattrs()
+    assert str(var) == ("<class 'metpy.io.cdm.Variable'>: int64 data(x, y)"
+                        "\n\tshape = (2, 3)")
 
-    @staticmethod
-    def test_add_group():
-        r'Test adding a group'
-        ds = Dataset()
-        grp = ds.createGroup('myGroup')
-        assert grp.name == 'myGroup'
-        assert 'myGroup' in ds.groups
 
-        assert str(ds) == "root\nGroups:\nmyGroup"
+def test_remove_attr():
+    r'Test removing an attribute'
+    ds = Dataset()
+    ds.maker = 'me'
+    assert 'maker' in ds.ncattrs()
 
-    @staticmethod
-    @raises(ValueError)
-    def test_variable_size_check():
-        r'Test Variable checking size of passed array'
-        ds = Dataset()
-        xdim = ds.createDimension('x', 2)
-        ydim = ds.createDimension('y', 3)
+    del ds.maker
+    assert not hasattr(ds, 'maker')
+    assert 'maker' not in ds.ncattrs()
 
-        # Create array with dims flipped
-        arr = np.empty((ydim.size, xdim.size), dtype='f4')
 
+def test_add_group():
+    r'Test adding a group'
+    ds = Dataset()
+    grp = ds.createGroup('myGroup')
+    assert grp.name == 'myGroup'
+    assert 'myGroup' in ds.groups
+
+    assert str(ds) == "root\nGroups:\nmyGroup"
+
+
+def test_variable_size_check():
+    r'Test Variable checking size of passed array'
+    ds = Dataset()
+    xdim = ds.createDimension('x', 2)
+    ydim = ds.createDimension('y', 3)
+
+    # Create array with dims flipped
+    arr = np.empty((ydim.size, xdim.size), dtype='f4')
+
+    with pytest.raises(ValueError):
         ds.createVariable('data', 'f4', ('x', 'y'), wrap_array=arr)

--- a/metpy/io/tests/test_gini.py
+++ b/metpy/io/tests/test_gini.py
@@ -4,80 +4,75 @@
 
 import logging
 from datetime import datetime
+from numpy.testing import assert_almost_equal
 
-from nose.tools import assert_almost_equal, eq_, nottest
 from metpy.io.gini import GiniFile, GiniProjection
 from metpy.cbook import get_test_data
 
 log = logging.getLogger('metpy.io.gini')
 log.setLevel(logging.ERROR)
 
-get_test_data = nottest(get_test_data)
+
+def test_gini_basic():
+    'Basic test of GINI reading'
+    f = GiniFile(get_test_data('WEST-CONUS_4km_WV_20151208_2200.gini'))
+    pdb = f.prod_desc
+    assert pdb.source == 1
+    assert pdb.creating_entity == 'GOES-15'
+    assert pdb.sector_id == 'West CONUS'
+    assert pdb.channel == 'WV (6.5/6.7 micron)'
+    assert pdb.num_records == 1280
+    assert pdb.record_len == 1100
+    assert pdb.datetime, datetime(2015, 12, 8, 22, 0, 19 == 0)
+    assert pdb.projection == GiniProjection.lambert_conformal
+    assert pdb.nx == 1100
+    assert pdb.ny == 1280
+    assert_almost_equal(pdb.la1, 12.19, 4)
+    assert_almost_equal(pdb.lo1, -133.4588, 4)
+
+    proj = f.proj_info
+    assert proj.reserved == 0
+    assert_almost_equal(proj.lov, -95.0, 4)
+    assert_almost_equal(proj.dx, 4.0635, 4)
+    assert_almost_equal(proj.dy, 4.0635, 4)
+    assert proj.proj_center == 0
+
+    pdb2 = f.prod_desc2
+    assert pdb2.scanning_mode == [False, False, False]
+    assert_almost_equal(pdb2.lat_in, 25.0, 4)
+    assert pdb2.resolution == 4
+    assert pdb2.compression == 0
+    assert pdb2.version == 1
+    assert pdb2.pdb_size == 512
+
+    assert f.data.shape, (pdb.num_records == pdb.record_len)
 
 
-class TestGini(object):
-    'Tests for GINI file reader'
-    @staticmethod
-    def basic_test():
-        'Basic test of GINI reading'
-        f = GiniFile(get_test_data('WEST-CONUS_4km_WV_20151208_2200.gini'))
-        pdb = f.prod_desc
-        eq_(pdb.source, 1)
-        eq_(pdb.creating_entity, 'GOES-15')
-        eq_(pdb.sector_id, 'West CONUS')
-        eq_(pdb.channel, 'WV (6.5/6.7 micron)')
-        eq_(pdb.num_records, 1280)
-        eq_(pdb.record_len, 1100)
-        eq_(pdb.datetime, datetime(2015, 12, 8, 22, 0, 19, 0))
-        eq_(pdb.projection, GiniProjection.lambert_conformal)
-        eq_(pdb.nx, 1100)
-        eq_(pdb.ny, 1280)
-        assert_almost_equal(pdb.la1, 12.19, 4)
-        assert_almost_equal(pdb.lo1, -133.4588, 4)
+def test_gini_bad_size():
+    'Test reading a GINI file that reports a bad header size'
+    f = GiniFile(get_test_data('NHEM-MULTICOMP_1km_IR_20151208_2100.gini'))
+    pdb2 = f.prod_desc2
+    assert pdb2.pdb_size == 512  # Catching bad size
 
-        proj = f.proj_info
-        eq_(proj.reserved, 0)
-        assert_almost_equal(proj.lov, -95.0, 4)
-        assert_almost_equal(proj.dx, 4.0635, 4)
-        assert_almost_equal(proj.dy, 4.0635, 4)
-        eq_(proj.proj_center, 0)
 
-        pdb2 = f.prod_desc2
-        eq_(pdb2.scanning_mode, [False, False, False])
-        assert_almost_equal(pdb2.lat_in, 25.0, 4)
-        eq_(pdb2.resolution, 4)
-        eq_(pdb2.compression, 0)
-        eq_(pdb2.version, 1)
-        eq_(pdb2.pdb_size, 512)
+def test_gini_dataset():
+    'Test the dataset interface for GINI'
+    f = GiniFile(get_test_data('WEST-CONUS_4km_WV_20151208_2200.gini'))
+    ds = f.to_dataset()
+    assert 'x' in ds.variables
+    assert 'y' in ds.variables
+    assert 'WV' in ds.variables
+    assert hasattr(ds.variables['WV'], 'grid_mapping')
+    assert ds.variables['WV'].grid_mapping in ds.variables
+    assert_almost_equal(ds.variables['lon'][0, 0], f.prod_desc.lo1, 4)
+    assert_almost_equal(ds.variables['lat'][0, 0], f.prod_desc.la1, 4)
 
-        eq_(f.data.shape, (pdb.num_records, pdb.record_len))
 
-    @staticmethod
-    def test_bad_size():
-        'Test reading a GINI file that reports a bad header size'
-        f = GiniFile(get_test_data('NHEM-MULTICOMP_1km_IR_20151208_2100.gini'))
-        pdb2 = f.prod_desc2
-        eq_(pdb2.pdb_size, 512)  # Catching bad size
-
-    @staticmethod
-    def test_dataset():
-        'Test the dataset interface for GINI'
-        f = GiniFile(get_test_data('WEST-CONUS_4km_WV_20151208_2200.gini'))
-        ds = f.to_dataset()
-        assert 'x' in ds.variables
-        assert 'y' in ds.variables
-        assert 'WV' in ds.variables
-        assert hasattr(ds.variables['WV'], 'grid_mapping')
-        assert ds.variables['WV'].grid_mapping in ds.variables
-        assert_almost_equal(ds.variables['lon'][0, 0], f.prod_desc.lo1, 4)
-        assert_almost_equal(ds.variables['lat'][0, 0], f.prod_desc.la1, 4)
-
-    @staticmethod
-    def test_str():
-        'Test the str representation of GiniFile'
-        f = GiniFile(get_test_data('WEST-CONUS_4km_WV_20151208_2200.gini'))
-        truth = ('GiniFile: GOES-15 West CONUS WV (6.5/6.7 micron)\n'
-                 '\tTime: 2015-12-08 22:00:19\n\tSize: 1280x1100\n'
-                 '\tProjection: lambert_conformal\n'
-                 '\tLower Left Corner (Lon, Lat): (-133.4588, 12.19)\n\tResolution: 4km')
-        assert str(f) == truth
+def test_gini_str():
+    'Test the str representation of GiniFile'
+    f = GiniFile(get_test_data('WEST-CONUS_4km_WV_20151208_2200.gini'))
+    truth = ('GiniFile: GOES-15 West CONUS WV (6.5/6.7 micron)\n'
+             '\tTime: 2015-12-08 22:00:19\n\tSize: 1280x1100\n'
+             '\tProjection: lambert_conformal\n'
+             '\tLower Left Corner (Lon, Lat): (-133.4588, 12.19)\n\tResolution: 4km')
+    assert str(f) == truth

--- a/metpy/io/tests/test_nexrad.py
+++ b/metpy/io/tests/test_nexrad.py
@@ -8,11 +8,8 @@ import os.path
 
 import numpy as np
 
-import nose.tools
 from metpy.io.nexrad import Level2File, Level3File, is_precip_mode
 from metpy.cbook import get_test_data
-
-get_test_data = nose.tools.nottest(get_test_data)
 
 # Turn off the warnings for tests
 logging.getLogger("metpy.io.nexrad").setLevel(logging.CRITICAL)

--- a/metpy/plots/tests/test_ctables.py
+++ b/metpy/plots/tests/test_ctables.py
@@ -12,13 +12,12 @@ except ImportError:
     buffer_args = dict(buffering=1)
 
 import numpy as np
-from nose.tools import eq_
 from metpy.plots.ctables import ColortableRegistry, convert_gempak_table
 
 
 class TestColortableRegistry(object):
     'Tests for ColortableRegistry'
-    def setUp(self):  # noqa
+    def setup_method(self, _):  # noqa
         'Set up a registry for use by the tests.'
         self.reg = ColortableRegistry()
 
@@ -36,7 +35,7 @@ class TestColortableRegistry(object):
         name = os.path.splitext(os.path.basename(fobj.name))[0]
 
         assert name in self.reg
-        eq_(self.reg[name], [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)])
+        assert self.reg[name] == [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)]
 
     def test_read_file(self):
         'Test reading a colortable from a file'
@@ -53,32 +52,32 @@ class TestColortableRegistry(object):
         self.reg['table'] = true_colors
 
         table = self.reg.get_colortable('table')
-        eq_(table.N, 2)
-        eq_(table.colors, true_colors)
+        assert table.N == 2
+        assert table.colors == true_colors
 
     def test_get_steps(self):
         'Test getting a colortable and norm with appropriate steps'
         self.reg['table'] = [(0.0, 0.0, 1.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
         norm, cmap = self.reg.get_with_steps('table', 5., 10.)
-        eq_(cmap(norm(np.array([6.]))).tolist(), [[0.0, 0.0, 1.0, 1.0]])
-        eq_(cmap(norm(np.array([14.9]))).tolist(), [[0.0, 0.0, 1.0, 1.0]])
-        eq_(cmap(norm(np.array([15.1]))).tolist(), [[1.0, 0.0, 0.0, 1.0]])
-        eq_(cmap(norm(np.array([26.]))).tolist(), [[0.0, 1.0, 0.0, 1.0]])
+        assert cmap(norm(np.array([6.]))).tolist() == [[0.0, 0.0, 1.0, 1.0]]
+        assert cmap(norm(np.array([14.9]))).tolist() == [[0.0, 0.0, 1.0, 1.0]]
+        assert cmap(norm(np.array([15.1]))).tolist() == [[1.0, 0.0, 0.0, 1.0]]
+        assert cmap(norm(np.array([26.]))).tolist() == [[0.0, 1.0, 0.0, 1.0]]
 
     def test_get_steps_negative_start(self):
         'Test for issue #81 (bad start for get with steps)'
         self.reg['table'] = [(0.0, 0.0, 1.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
         norm, cmap = self.reg.get_with_steps('table', -10, 5)
-        eq_(norm.vmin, -10)
-        eq_(norm.vmax, 5)
+        assert norm.vmin == -10
+        assert norm.vmax == 5
 
     def test_get_boundaries(self):
         'Test getting a colortable with explicit boundaries'
         self.reg['table'] = [(0.0, 0.0, 1.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
         norm, cmap = self.reg.get_with_boundaries('table', [0., 8., 10., 20.])
-        eq_(cmap(norm(np.array([7.]))).tolist(), [[0.0, 0.0, 1.0, 1.0]])
-        eq_(cmap(norm(np.array([9.]))).tolist(), [[1.0, 0.0, 0.0, 1.0]])
-        eq_(cmap(norm(np.array([10.1]))).tolist(), [[0.0, 1.0, 0.0, 1.0]])
+        assert cmap(norm(np.array([7.]))).tolist() == [[0.0, 0.0, 1.0, 1.0]]
+        assert cmap(norm(np.array([9.]))).tolist() == [[1.0, 0.0, 0.0, 1.0]]
+        assert cmap(norm(np.array([10.1]))).tolist() == [[0.0, 1.0, 0.0, 1.0]]
 
 
 def test_gempak():

--- a/metpy/plots/tests/test_skewt.py
+++ b/metpy/plots/tests/test_skewt.py
@@ -13,67 +13,61 @@ from metpy.units import units
 
 # TODO: Need at some point to do image-based comparison, but that's a lot to
 # bite off right now
-class TestSkewT(object):
-    'Test SkewT'
-    @staticmethod
-    def test_api():
-        'Test the SkewT api'
-        fig = Figure(figsize=(9, 9))
-        skew = SkewT(fig)
+def test_skewt_api():
+    'Test the SkewT api'
+    fig = Figure(figsize=(9, 9))
+    skew = SkewT(fig)
 
-        # Plot the data using normal plotting functions, in this case using
-        # log scaling in Y, as dictated by the typical meteorological plot
-        p = np.linspace(1000, 100, 10)
-        t = np.linspace(20, -20, 10)
-        u = np.linspace(-10, 10, 10)
-        skew.plot(p, t, 'r')
-        skew.plot_barbs(p, u, u)
+    # Plot the data using normal plotting functions, in this case using
+    # log scaling in Y, as dictated by the typical meteorological plot
+    p = np.linspace(1000, 100, 10)
+    t = np.linspace(20, -20, 10)
+    u = np.linspace(-10, 10, 10)
+    skew.plot(p, t, 'r')
+    skew.plot_barbs(p, u, u)
 
-        # Add the relevant special lines
-        skew.plot_dry_adiabats()
-        skew.plot_moist_adiabats()
-        skew.plot_mixing_lines()
+    # Add the relevant special lines
+    skew.plot_dry_adiabats()
+    skew.plot_moist_adiabats()
+    skew.plot_mixing_lines()
 
-        with tempfile.NamedTemporaryFile() as f:
-            FigureCanvasAgg(fig).print_png(f.name)
-
-    @staticmethod
-    def test_subplot():
-        'Test using SkewT on a sub-plot'
-        fig = Figure(figsize=(9, 9))
-        SkewT(fig, subplot=(2, 2, 1))
-        with tempfile.NamedTemporaryFile() as f:
-            FigureCanvasAgg(fig).print_png(f.name)
-
-    @staticmethod
-    def test_gridspec():
-        'Test using SkewT on a sub-plot'
-        fig = Figure(figsize=(9, 9))
-        gs = GridSpec(1, 2)
-        SkewT(fig, subplot=gs[0, 1])
-        with tempfile.NamedTemporaryFile() as f:
-            FigureCanvasAgg(fig).print_png(f.name)
+    with tempfile.NamedTemporaryFile() as f:
+        FigureCanvasAgg(fig).print_png(f.name)
 
 
-class TestHodograph(object):
-    'Test Hodograph'
-    @staticmethod
-    def test_basic_api():
-        'Basic test of Hodograph API'
-        fig = Figure(figsize=(9, 9))
-        ax = fig.add_subplot(1, 1, 1)
-        hodo = Hodograph(ax, component_range=60)
-        hodo.add_grid(increment=5, color='k')
-        hodo.plot([1, 10], [1, 10], color='red')
-        hodo.plot_colormapped([1, 3, 5, 10], [2, 4, 6, 11], [0.1, 0.3, 0.5, 0.9], cmap='Greys')
+def test_skewt_subplot():
+    'Test using SkewT on a sub-plot'
+    fig = Figure(figsize=(9, 9))
+    SkewT(fig, subplot=(2, 2, 1))
+    with tempfile.NamedTemporaryFile() as f:
+        FigureCanvasAgg(fig).print_png(f.name)
 
-    @staticmethod
-    def test_units():
-        'Test passing unit-ed quantities to Hodograph'
-        fig = Figure(figsize=(9, 9))
-        ax = fig.add_subplot(1, 1, 1)
-        hodo = Hodograph(ax)
-        u = np.arange(10) * units.kt
-        v = np.arange(10) * units.kt
-        hodo.plot(u, v)
-        hodo.plot_colormapped(u, v, np.sqrt(u * u + v * v), cmap='Greys')
+
+def test_skewt_gridspec():
+    'Test using SkewT on a sub-plot'
+    fig = Figure(figsize=(9, 9))
+    gs = GridSpec(1, 2)
+    SkewT(fig, subplot=gs[0, 1])
+    with tempfile.NamedTemporaryFile() as f:
+        FigureCanvasAgg(fig).print_png(f.name)
+
+
+def test_hodograph_api():
+    'Basic test of Hodograph API'
+    fig = Figure(figsize=(9, 9))
+    ax = fig.add_subplot(1, 1, 1)
+    hodo = Hodograph(ax, component_range=60)
+    hodo.add_grid(increment=5, color='k')
+    hodo.plot([1, 10], [1, 10], color='red')
+    hodo.plot_colormapped([1, 3, 5, 10], [2, 4, 6, 11], [0.1, 0.3, 0.5, 0.9], cmap='Greys')
+
+
+def test_hodograph_units():
+    'Test passing unit-ed quantities to Hodograph'
+    fig = Figure(figsize=(9, 9))
+    ax = fig.add_subplot(1, 1, 1)
+    hodo = Hodograph(ax)
+    u = np.arange(10) * units.kt
+    v = np.arange(10) * units.kt
+    hodo.plot(u, v)
+    hodo.plot_colormapped(u, v, np.sqrt(u * u + v * v), cmap='Greys')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs = examples docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,6 @@ versionfile_source = metpy/_version.py
 versionfile_build = metpy/_version.py
 tag_prefix = v
 parentdir_prefix = metpy-
+
+[aliases]
+test = pytest

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ setup(
 
     packages=find_packages(exclude=['doc', 'examples']),
     package_data={'metpy.plots': ['colortables/*.tbl', 'nexrad_tables/*.tbl']},
-    test_suite="nose.collector",
 
     install_requires=dependencies,
     extras_require={
@@ -83,7 +82,7 @@ setup(
         'dev': ['ipython[all]>=3.1'],
         'doc': ['sphinx>=1.3', 'ipython[all]>=3.1'],
         'examples': ['cartopy>=0.13','pillow'],
-        'test': ['nose']
+        'test': ['pytest', 'pytest-runner']
     },
 
     cmdclass=commands,


### PR DESCRIPTION
Fixes #113.

Seems like nose is no longer maintained, and py.test is the most popular community option.

Not too hard. Biggest change is to replace some classes that were only used for grouping tests with sets of functions (py.test doesn't like `staticmethod` test functions). Also replace nose `eq_` with `assert`, since py.test does a good job giving useful output for plain asserts.