### PR TITLE
Documentation build updates

### DIFF
--- a/.checkignore
+++ b/.checkignore
@@ -7,4 +7,4 @@ metpy/_version.py
 versioneer.py
 
 # Don't scan sphinx config
-docs/conf.py
+docs/source/conf.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ before_install:
     fi
 
 install:
-  - if [[ $TASK != "lint" ]]; then
+  - if [[ $TASK != "lint" && $TASK != "docs" ]]; then
       pip install ".[$EXTRA_INSTALLS]" --upgrade --no-index -f file://$PWD/$WHEELDIR $VERSIONS;
       if [[ $TASK == "examples" ]]; then
         python setup.py examples;
@@ -94,7 +94,12 @@ script:
       flake8 metpy;
     elif [[ $TASK == "docs" ]]; then
       cd docs;
-      make html;
+      make html 2>docs.log;
+      if [ -s docs.log ]; then
+        echo Doc build produced warnings or errors:;
+        cat docs.log;
+        false;
+      fi;
     elif [[ $TASK == "examples" ]]; then
       pushd examples/notebooks;
       export TEST_DATA_DIR=${TRAVIS_BUILD_DIR}/testdata;

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,13 +55,13 @@ matrix:
     - python: nightly
 
 before_install:
+  - pip install --upgrade pip;
   - if [[ $TASK == "lint" ]]; then
       pip install flake8 pep8-naming;
+    elif [[ $TASK == "docs" ]]; then
+        pip install -r docs/requirements.txt -f $WHEELHOUSE;
     else
-      pip install --upgrade pip;
-      if [[ $TASK == "docs" ]]; then
-        pip install -r docs/requirements.txt;
-      elif [[ $TASK == "examples" ]]; then
+      if [[ $TASK == "examples" ]]; then
         export EXTRA_INSTALLS="$EXTRA_INSTALLS,examples";
         export EXTRA_PACKAGES="Cython nbconvert ipykernel";
       else

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
 sphinx>=1.3
 nbconvert>=4.1
-jsonschema

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx>=1.3
 nbconvert>=4.1
+enum34

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,6 +43,8 @@ if 'READTHEDOCS' in os.environ or 'TRAVIS' in os.environ:
     for mod_name in MOCK_MODULES:
         sys.modules[mod_name] = mock.Mock()
 
+    sys.modules['matplotlib'].__version__ = '1.5'
+
     class MockUnit(float):
         def to_base_units(self):
             return self

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,6 +48,8 @@ if 'READTHEDOCS' in os.environ or 'TRAVIS' in os.environ:
             return self
         def __call__(self, arg):
             return self
+        def to(self, arg):
+            return self
 
     class MockUnits(object):
         def __getattr__(self, attr):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,10 +34,11 @@ if 'READTHEDOCS' in os.environ or 'TRAVIS' in os.environ:
     MOCK_MODULES = ['matplotlib', 'matplotlib.axis', 'matplotlib.axes',
                     'matplotlib.backends', 'matplotlib.cbook',
                     'matplotlib.collections', 'matplotlib.colors',
+                    'matplotlib.font_manager',
                     'matplotlib.figure', 'matplotlib.patches',
                     'matplotlib.projections', 'matplotlib.pyplot',
-                    'matplotlib.spines', 'matplotlib.ticker',
-                    'matplotlib.transforms',
+                    'matplotlib.quiver', 'matplotlib.spines',
+                    'matplotlib.ticker', 'matplotlib.transforms',
                     'numpy', 'numpy.ma', 'numpy.testing', 'pint', 'pint.unit',
                     'scipy', 'scipy.constants', 'scipy.integrate']
     for mod_name in MOCK_MODULES:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 # which is unused, so that pandoc will run
 # 
 
-if 'READTHEDOCS' in os.environ:
+if 'READTHEDOCS' in os.environ or 'TRAVIS' in os.environ:
     import mock
 
     MOCK_MODULES = ['matplotlib', 'matplotlib.axis', 'matplotlib.axes',

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -60,9 +60,11 @@ __ https://github.com/metpy/MetPy/issues
 Presentations
 -------------
 
-* Ryan May's talk and tutorial on MetPy at the `2015 Unidata Users Workshop`__.
+* Ryan May's talk and tutorial on MetPy at the `2015 Unidata Users Workshop`_.
+* Presentation on MetPy at the `2016 AMS Annual Meeting`_ by Ryan May.
 
-__ https://www.youtube.com/watch?v=umwauHAL-0M
+.. _`2015 Unidata Users Workshop`: https://www.youtube.com/watch?v=umwauHAL-0M
+.. _`2016 AMS Annual Meeting`: https://ams.confex.com/ams/96Annual/webprogram/Paper286983.html
 
 -------
 License

--- a/docs/source/notebook_gen_sphinxext.py
+++ b/docs/source/notebook_gen_sphinxext.py
@@ -4,6 +4,9 @@
 import glob
 import os
 import os.path
+import warnings
+
+warnings.simplefilter('ignore')
 
 from nbconvert.exporters import rst
 

--- a/metpy/plots/station_plot.py
+++ b/metpy/plots/station_plot.py
@@ -470,8 +470,9 @@ with exporter:
     simple_layout.add_symbol('C', 'cloud_coverage', sky_cover)
     simple_layout.add_symbol('W', 'present_weather', current_weather)
 
-    #: :desc: Full NWS station plot layout from
-    #: http://oceanservice.noaa.gov/education/yos/resource/JetStream/synoptic/wxmaps.htm
+    #: Full NWS station plot `layout`__
+    #:
+    #: __ http://oceanservice.noaa.gov/education/yos/resource/JetStream/synoptic/wxmaps.htm
     nws_layout = StationPlotLayout()
     nws_layout.add_value((-1, 1), 'air_temperature', units='degF')
     nws_layout.add_symbol((0, 2), 'high_cloud_type', high_clouds)


### PR DESCRIPTION
Alright, this is the last time read the docs is going to fail on me silently. So this:
- Makes the Travis set-up mimic RTD by not installing (thus relying on mocked modules)
- Captures sphinx standard error to get any warnings/errors and fails the build if it's not empty (displaying errors of course)

Also cleans up a dependency and adds a link to my AMS talk.