### PR TITLE
MNT: Ignore flake8's new 405 errors.

### DIFF
--- a/metpy/_version.py
+++ b/metpy/_version.py
@@ -155,7 +155,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # "stabilization", as well as "HEAD" and "master".
         tags = set([r for r in refs if re.search(r'\d', r)])
         if verbose:
-            print("discarding '%s', no digits" % ",".join(refs-tags))
+            print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
         print("likely tags: %s" % ",".join(sorted(tags)))
     for ref in sorted(tags):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [flake8]
+ignore = F405
 max-line-length = 95
 
 [metadata]


### PR DESCRIPTION
We're careful about wildcard imports, they're all in tests or setting up
package __init__'s.